### PR TITLE
Delete photos by selecting days

### DIFF
--- a/delete_photos.js
+++ b/delete_photos.js
@@ -5,7 +5,7 @@ const maxImageCount = "ALL_PHOTOS";
 
 // Selector for Images and buttons
 const ELEMENT_SELECTORS = {
-    checkboxClass: '.ckGgle',
+    checkboxClass: '.QcpS9c.R4HkWb',
     deleteButton: 'button[aria-label="Delete"]',
     languageAgnosticDeleteButton: 'div[data-delete-origin] > button',
     deleteButton: 'button[aria-label="Delete"]',
@@ -47,7 +47,7 @@ let deleteTask = setInterval(() => {
     imageCount += checkboxes.length;
 
     checkboxes.forEach((checkbox) => { checkbox.click() });
-    console.log("[INFO] Deleting", checkboxes.length, "images");
+    console.log("[INFO] Deleting", checkboxes.length, "days of images");
 
     setTimeout(() => {
         try {


### PR DESCRIPTION
In the case where users have a lot of photos uploaded in a single day, this is significantly faster.
In the case where they do not, it should be roughly the same.

This has not been tested on anything other than my account, so it would be good to see how well it works for others.