### PR TITLE
Update delete_photos.js

### DIFF
--- a/delete_photos.js
+++ b/delete_photos.js
@@ -57,7 +57,7 @@ let deleteTask = setInterval(() => {
     imageCount += checkboxes.length;
 
     checkboxes.forEach((checkbox) => { checkbox.click() });
-    console.log("[INFO] Deleting", checkboxes.length, "images");
+    console.log("[INFO] Deleting", checkboxes.length, "images/sets");
 
     setTimeout(() => {
         try {
@@ -72,7 +72,7 @@ let deleteTask = setInterval(() => {
             buttons.confirmation_button = document.querySelector(ELEMENT_SELECTORS['confirmationButton']);
             buttons.confirmation_button.click();
 
-            console.log(`[INFO] ${imageCount}/${maxImageCount} Deleted`);
+            console.log(`[INFO] ${imageCount}/${maxImageCount} Images/Sets Deleted`);
             if (maxImageCount !== "ALL_PHOTOS" && imageCount >= parseInt(maxImageCount)) {
                 console.log(`${imageCount} photos deleted as requested`);
                 clearInterval(deleteTask);

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -11,8 +11,8 @@ const maxImageCount = "ALL_PHOTOS";
 
 // Selector for Images and buttons
 const ELEMENT_SELECTORS = {
-    // checkboxClass: '.ckGgle',		// Delete sets of photos at a time
-    checkboxClass: '.QcpS9c.R4HkWb', 	// Delete whole days at a time
+    checkboxClass: '.ckGgle',		// Delete sets of photos at a time
+    // checkboxClass: '.QcpS9c.R4HkWb', // Delete whole days at a time - Won't delete dates with only one image!
     languageAgnosticDeleteButton: 'div[data-delete-origin] button',
     deleteButton: 'button[aria-label="Delete"]',
     confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,82 +4,87 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-// How many photos to delete?
-// Put a number value, like this
-// const maxImageCount = 5896
-const maxImageCount = "ALL_PHOTOS";
-
-// Selector for Images and buttons
-const ELEMENT_SELECTORS = {
-    checkboxClass: '.ckGgle',		// Delete sets of photos at a time
-    // checkboxClass: '.QcpS9c.R4HkWb', // Delete whole days at a time - Won't delete dates with only one image!
-    languageAgnosticDeleteButton: 'div[data-delete-origin] button',
-    deleteButton: 'button[aria-label="Delete"]',
-    confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'
-}
-
-// Time Configuration (in milliseconds)
-const TIME_CONFIG = {
-    delete_cycle: 10000,
-    press_button_delay: 2000,
-   	check_sleep_delay: 200
+let deleteIt = function() {
+	// How many photos to delete?
+	// Put a number value, like this
+	// const maxImageCount = 5896
+	const maxImageCount = "ALL_PHOTOS";
+	
+	// Selector for Images and buttons
+	const ELEMENT_SELECTORS = {
+	    checkboxClass: '.ckGgle',		// Delete sets of photos at a time
+	    // checkboxClass: '.QcpS9c.R4HkWb', // Delete whole days at a time - Won't delete dates with only one image!
+	    languageAgnosticDeleteButton: 'div[data-delete-origin] button',
+	    deleteButton: 'button[aria-label="Delete"]',
+	    confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'
+	}
+	
+	// Time Configuration (in milliseconds)
+	const TIME_CONFIG = {
+	    delete_cycle: 10000,
+	    press_button_delay: 2000,
+	   	check_sleep_delay: 200
+	};
+	
+	const MAX_RETRIES = 10;
+	
+	// Force sleep a bit
+	const sleep = ms => new Promise(r => setTimeout(r, ms));
+	
+	let imageCount = 0;
+	
+	let checkboxes;
+	let buttons = {
+	    deleteButton: null,
+	    confirmationButton: null
+	}
+	
+	let deleteTask = setInterval(() => {
+	    let attemptCount = 1;
+	
+	    do {
+	        checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
+			sleep(TIME_CONFIG['check_sleep_delay']); // Give a bit of extra time for the page to load more
+	    } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);
+	
+	    if (checkboxes.length <= 0) {
+	        console.log("[INFO] No more images to delete.");
+	        // Comment out the next three lines if you have 10k+ photos and don't want to risk it quitting part way through
+	        clearInterval(deleteTask);
+	        console.log("[SUCCESS] Tool exited.");
+	        return;
+	    }
+	
+	    imageCount += checkboxes.length;
+	
+	    checkboxes.forEach((checkbox) => { checkbox.click() });
+	    console.log("[INFO] Deleting", checkboxes.length, "images/sets");
+	
+	    setTimeout(() => {
+	        try {
+	            buttons.deleteButton = document.querySelector(ELEMENT_SELECTORS['languageAgnosticDeleteButton']);
+	            buttons.deleteButton.click();
+	        } catch {
+	            buttons.deleteButton = document.querySelector(ELEMENT_SELECTORS['deleteButton']);
+	            buttons.deleteButton.click();
+	        }
+	
+	        setTimeout(() => {
+	            buttons.confirmation_button = document.querySelector(ELEMENT_SELECTORS['confirmationButton']);
+	            buttons.confirmation_button.click();
+	
+	            console.log(`[INFO] ${imageCount}/${maxImageCount} Images/Sets Deleted`);
+	            if (maxImageCount !== "ALL_PHOTOS" && imageCount >= parseInt(maxImageCount)) {
+	                console.log(`${imageCount} photos deleted as requested`);
+	                clearInterval(deleteTask);
+	                console.log("[SUCCESS] Tool exited.");
+	                return;
+	            }
+	
+	        }, TIME_CONFIG['press_button_delay']);
+	    }, TIME_CONFIG['press_button_delay']);
+	}, TIME_CONFIG['delete_cycle']);
 };
 
-const MAX_RETRIES = 10;
-
-// Force sleep a bit
-const sleep = ms => new Promise(r => setTimeout(r, ms));
-
-let imageCount = 0;
-
-let checkboxes;
-let buttons = {
-    deleteButton: null,
-    confirmationButton: null
-}
-
-let deleteTask = setInterval(() => {
-    let attemptCount = 1;
-
-    do {
-        checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
-		sleep(TIME_CONFIG['check_sleep_delay']); // Give a bit of extra time for the page to load more
-    } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);
-
-    if (checkboxes.length <= 0) {
-        console.log("[INFO] No more images to delete.");
-        // Comment out the next three lines if you have 10k+ photos and don't want to risk it quitting part way through
-        clearInterval(deleteTask);
-        console.log("[SUCCESS] Tool exited.");
-        return;
-    }
-
-    imageCount += checkboxes.length;
-
-    checkboxes.forEach((checkbox) => { checkbox.click() });
-    console.log("[INFO] Deleting", checkboxes.length, "images/sets");
-
-    setTimeout(() => {
-        try {
-            buttons.deleteButton = document.querySelector(ELEMENT_SELECTORS['languageAgnosticDeleteButton']);
-            buttons.deleteButton.click();
-        } catch {
-            buttons.deleteButton = document.querySelector(ELEMENT_SELECTORS['deleteButton']);
-            buttons.deleteButton.click();
-        }
-
-        setTimeout(() => {
-            buttons.confirmation_button = document.querySelector(ELEMENT_SELECTORS['confirmationButton']);
-            buttons.confirmation_button.click();
-
-            console.log(`[INFO] ${imageCount}/${maxImageCount} Images/Sets Deleted`);
-            if (maxImageCount !== "ALL_PHOTOS" && imageCount >= parseInt(maxImageCount)) {
-                console.log(`${imageCount} photos deleted as requested`);
-                clearInterval(deleteTask);
-                console.log("[SUCCESS] Tool exited.");
-                return;
-            }
-
-        }, TIME_CONFIG['press_button_delay']);
-    }, TIME_CONFIG['press_button_delay']);
-}, TIME_CONFIG['delete_cycle']);
+// Do stuff
+deleteIt(); // Rerun this line to start the program again

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -1,3 +1,9 @@
+/* 
+Mass delete google photos
+Works best in Chrom(ium); Firefox works but can have loading issues and timing issues with HUGE photo sets. 
+https://github.com/mrishab/google-photos-delete-tool/
+*/
+
 // How many photos to delete?
 // Put a number value, like this
 // const maxImageCount = 5896
@@ -14,10 +20,14 @@ const ELEMENT_SELECTORS = {
 // Time Configuration (in milliseconds)
 const TIME_CONFIG = {
     delete_cycle: 10000,
-    press_button_delay: 2000
+    press_button_delay: 2000,
+   	check_sleep_delay: 200
 };
 
 const MAX_RETRIES = 10;
+
+// Force sleep a bit
+const sleep = ms => new Promise(r => setTimeout(r, ms));
 
 let imageCount = 0;
 
@@ -32,12 +42,12 @@ let deleteTask = setInterval(() => {
 
     do {
         checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
-
+		sleep(TIME_CONFIG['check_sleep_delay']); // Give a bit of extra time for the page to load more
     } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);
-
 
     if (checkboxes.length <= 0) {
         console.log("[INFO] No more images to delete.");
+        // Comment out the next three lines if you have 10k+ photos and don't want to risk it quitting part way through
         clearInterval(deleteTask);
         console.log("[SUCCESS] Tool exited.");
         return;

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -11,7 +11,8 @@ const maxImageCount = "ALL_PHOTOS";
 
 // Selector for Images and buttons
 const ELEMENT_SELECTORS = {
-    checkboxClass: '.ckGgle',
+    // checkboxClass: '.ckGgle',		// Delete sets of photos at a time
+    checkboxClass: '.QcpS9c.R4HkWb', 	// Delete whole days at a time
     languageAgnosticDeleteButton: 'div[data-delete-origin] button',
     deleteButton: 'button[aria-label="Delete"]',
     confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'


### PR DESCRIPTION
- Added an extra pause for page loads - helps with HUGE libraries. 
- Added a comment regarding an option that can help with premature stops on some big libraries. 
- Added a header comment
- Set default sector to use days rather than individual photos - stolen from #43. 
  - HUGE speed up for big photo sets