### PR TITLE
Make deletion of all photos more robust, and a few other contributions merged

### DIFF
--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,7 +4,7 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteGooglePhotos = function(maxItemCount = "ALL_PHOTOS", itemUnit = "days") {
+let deleteGooglePhotos = function(maxItemCount = "ALL_PHOTOS", itemUnit = "infinity") {
 
 	const CHECKBOX_CLASSES = {
 		days: '.QcpS9c.R4HkWb',	// Delete whole days at a time - Won't delete dates with only one image!

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -19,7 +19,6 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	const TIME_CONFIG = {
 	    delete_cycle: 10000,
 	    press_button_delay: 2000,
-	   	check_sleep_delay: 200
 	};
 	
 	const MAX_RETRIES = 10;
@@ -40,7 +39,9 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	
 	    do {
 	        checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
-			sleep(TIME_CONFIG['check_sleep_delay']); // Give a bit of extra time for the page to load more
+		 if (attemptCount > 1) {
+		     sleep(TIME_CONFIG['delete_cycle']); // Give a bit of extra time for the page to load more
+		 }
 	    } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);
 	
 	    if (checkboxes.length <= 0) {
@@ -82,7 +83,6 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	}, TIME_CONFIG['delete_cycle']);
 };
 
-// Do stuff
 // How many photos to delete?
 // Put a number value, like this
 //   deleteGooglePhotos(5896);

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -40,6 +40,7 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	    do {
 	        checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
 		 if (attemptCount > 1) {
+		     console.log("No checkboxes found; retrying, " + attemptCount + "/" + MAX_RETRIES);
 		     sleep(TIME_CONFIG['delete_cycle']); // Give a bit of extra time for the page to load more
 		 }
 	    } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -39,7 +39,7 @@ let deleteGooglePhotos = async function(maxItemCount = "ALL_PHOTOS", itemUnit = 
 	    confirmationButton: null
 	}
 	
-	let deleteTask = setInterval(async function () => {
+	let deleteTask = setInterval(async function () {
 	    let attemptCount = 1;
 	
 	    do {

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,7 +4,7 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteGooglePhotos = function(maxItemCount = "ALL_PHOTOS", itemUnit = "infinity") {
+let deleteGooglePhotos = async function(maxItemCount = "ALL_PHOTOS", itemUnit = "infinity") {
 
 	const CHECKBOX_CLASSES = {
 		days: '.QcpS9c.R4HkWb',	// Delete whole days at a time - Won't delete dates with only one image!
@@ -39,14 +39,14 @@ let deleteGooglePhotos = function(maxItemCount = "ALL_PHOTOS", itemUnit = "infin
 	    confirmationButton: null
 	}
 	
-	let deleteTask = setInterval(() => {
+	let deleteTask = setInterval(async function () => {
 	    let attemptCount = 1;
 	
 	    do {
 	        checkboxes = document.querySelectorAll(ELEMENT_SELECTORS['checkboxClass']);
 		 if (attemptCount > 1) {
 		     console.log("No checkboxes found; retrying, " + attemptCount + "/" + MAX_RETRIES);
-		     sleep(TIME_CONFIG['delete_cycle']); // Give a bit of extra time for the page to load more
+		     await sleep(TIME_CONFIG['delete_cycle']); // Give a bit of extra time for the page to load more
 		 }
 	    } while (checkboxes.length <= 0 && attemptCount++ < MAX_RETRIES);
 	

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,12 +4,17 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
+let deleteGooglePhotos = function(maxItemCount = "ALL_PHOTOS", itemUnit = "days") {
+
+	const CHECKBOX_CLASSES = {
+		days: '.QcpS9c.R4HkWb',	// Delete whole days at a time - Won't delete dates with only one image!
+		photos: '.ckGgle',		// Delete sets of photos at a time
+		infinity: '.ckGgle'		// Delete everything and do not exit: if you have 10k+ photos and don't want to risk it quitting part way through
+	}
 	
 	// Selector for Images and buttons
 	const ELEMENT_SELECTORS = {
-	    checkboxClass: '.ckGgle',		// Delete sets of photos at a time
-	    // checkboxClass: '.QcpS9c.R4HkWb', // Delete whole days at a time - Won't delete dates with only one image!
+	    checkboxClass: CHECKBOX_CLASSES[itemUnit], 
 	    languageAgnosticDeleteButton: 'div[data-delete-origin] button',
 	    deleteButton: 'button[aria-label="Delete"]',
 	    confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'
@@ -47,10 +52,11 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	
 	    if (checkboxes.length <= 0) {
 	        console.log("[INFO] No more images to delete.");
-	        // Comment out the next three lines if you have 10k+ photos and don't want to risk it quitting part way through
-	        clearInterval(deleteTask);
-	        console.log("[SUCCESS] Tool exited.");
-	        return;
+		 if (itemUnit != "infinity") {
+		        clearInterval(deleteTask);
+		        console.log("[SUCCESS] Tool exited.");
+	       	 return;
+		 }
 	    }
 	
 	    imageCount += checkboxes.length;
@@ -71,8 +77,8 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	            buttons.confirmation_button = document.querySelector(ELEMENT_SELECTORS['confirmationButton']);
 	            buttons.confirmation_button.click();
 	
-	            console.log(`[INFO] ${imageCount}/${maxImageCount} Images/Sets Deleted`);
-	            if (maxImageCount !== "ALL_PHOTOS" && imageCount >= parseInt(maxImageCount)) {
+	            console.log(`[INFO] ${imageCount}/${maxItemCount} Images/Sets Deleted`);
+	            if (maxItemCount !== "ALL_PHOTOS" && imageCount >= parseInt(maxItemCount)) {
 	                console.log(`${imageCount} photos deleted as requested`);
 	                clearInterval(deleteTask);
 	                console.log("[SUCCESS] Tool exited.");
@@ -86,6 +92,6 @@ let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 
 // How many photos to delete?
 // Put a number value, like this
-//   deleteGooglePhotos(5896);
-// If the argument is missing, we will delete all photos.
+//   deleteGooglePhotos(5896, "photos");
+// If the first argument is missing, we will delete all photos.
 deleteGooglePhotos(); // Rerun this line to start the program again

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,7 +4,7 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteIt = function(maxImageCount = "ALL_PHOTOS") {
+let deleteGooglePhotos = function(maxImageCount = "ALL_PHOTOS") {
 	
 	// Selector for Images and buttons
 	const ELEMENT_SELECTORS = {
@@ -85,6 +85,6 @@ let deleteIt = function(maxImageCount = "ALL_PHOTOS") {
 // Do stuff
 // How many photos to delete?
 // Put a number value, like this
-//   deleteIt(5896);
+//   deleteGooglePhotos(5896);
 // If the argument is missing, we will delete all photos.
-deleteIt(); // Rerun this line to start the program again
+deleteGooglePhotos(); // Rerun this line to start the program again

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,7 +4,7 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteGooglePhotos = async function(maxItemCount = "ALL_PHOTOS", itemUnit = "infinity") {
+let deleteGooglePhotos = async function(maxItemCount = "ALL_PHOTOS", itemUnit = "photos") {
 
 	const CHECKBOX_CLASSES = {
 		days: '.QcpS9c.R4HkWb',	// Delete whole days at a time - Won't delete dates with only one image!

--- a/delete_photos.js
+++ b/delete_photos.js
@@ -4,11 +4,7 @@ Works best in Chrom(ium); Firefox works but can have loading issues and timing i
 https://github.com/mrishab/google-photos-delete-tool/
 */
 
-let deleteIt = function() {
-	// How many photos to delete?
-	// Put a number value, like this
-	// const maxImageCount = 5896
-	const maxImageCount = "ALL_PHOTOS";
+let deleteIt = function(maxImageCount = "ALL_PHOTOS") {
 	
 	// Selector for Images and buttons
 	const ELEMENT_SELECTORS = {
@@ -87,4 +83,8 @@ let deleteIt = function() {
 };
 
 // Do stuff
+// How many photos to delete?
+// Put a number value, like this
+//   deleteIt(5896);
+// If the argument is missing, we will delete all photos.
 deleteIt(); // Rerun this line to start the program again


### PR DESCRIPTION
This PR builds upon previous contributions:
- #43 by @ss23,
- #53 by @gpmidi,

and improves them a bit by:
- allowing the user to select how many items should be deleted and which kind of items through the called function's arguments,
- fixing the issue with huge sets (thousands of pictures) where the wait time for new checkboxes to re-appear can be quite long, and you'll need to sleep and retry.

This still needs some formatting and documentation to be improved.