### PR TITLE
Fix confirmation button selector

### DIFF
--- a/delete_photos.js
+++ b/delete_photos.js
@@ -8,7 +8,7 @@ const ELEMENT_SELECTORS = {
     checkboxClass: '.ckGgle',
     languageAgnosticDeleteButton: 'div[data-delete-origin] button',
     deleteButton: 'button[aria-label="Delete"]',
-    confirmationButton: '#yDmH0d > div.llhEMd.iWO5td > div > div.g3VIld.V639qd.bvQPzd.oEOLpc.Up8vH.J9Nfi.A9Uzve.iWO5td > div.XfpsVe.J9fJmf > button.VfPpkd-LgbsSe.VfPpkd-LgbsSe-OWXEXe-k8QpJ.nCP5yc.kHssdc.HvOprf'
+    confirmationButton: 'div[aria-modal="true"] > div > div > div > button:nth-of-type(2)'
 }
 
 // Time Configuration (in milliseconds)


### PR DESCRIPTION
The existing confirmation button selector here didn't work for me. I suspect the selector was using obfuscated values that change between release. I tried to come up with a selector that would be a bit more robust (though still sensitive to changes in page structure).