### PR TITLE
docs: point readers to the actively maintained v2 continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 # Google Photos Delete All Tool
 If you have ever wanted to delete your thousands of photos from the [Google Photos](https://photos.google.com/) but failed to find an easy way to do so, then this is the tool for you. This script goes through all your photos in Google Photos app on the desktop and deletes them. You can visually see the process while it happens!
 
+> **⚠️ Note (August 2026):** this original console-script repository has not been
+> updated since January 2025. Google Photos keeps changing its UI, so several bugs
+> reported in the issue tracker here (confirmation-button changes, first-run dialog,
+> deletion races) are not addressed in this code. An actively maintained continuation
+> exists:
+>
+> **[Google Photos Delete Tool v2](https://github.com/shtse8/Google-Photos-Delete-Tool)** —
+> Chrome extension, userscript, bookmarklet, or console paste, with resilient selectors,
+> localized UI, pause/resume, dry-run, and an empty-trash flow. Please report new issues
+> there. The original script below remains available for reference.
+
 # Getting Started
 Follow the step-by-step instructions below to run the tool.
 


### PR DESCRIPTION
## What

Adds a short notice at the top of the README directing visitors to the actively maintained continuation of this tool:

**[Google Photos Delete Tool v2](https://github.com/shtse8/Google-Photos-Delete-Tool)** — Chrome extension, userscript, bookmarklet, or console paste (v2.0.5, 2026-06), with resilient selectors, localized UI, pause/resume, dry-run, and an empty-trash flow.

## Why

- This repo's `delete_photos.js` has not been updated since January 2025.
- Google Photos keeps changing its DOM; the confirmation-button selector in this script is brittle and several open issues ([#40](https://github.com/mrishab/google-photos-delete-tool/issues/40), [#62](https://github.com/mrishab/google-photos-delete-tool/issues/62), [#74](https://github.com/mrishab/google-photos-delete-tool/issues/74), [#48](https://github.com/mrishab/google-photos-delete-tool/issues/48), [#32](https://github.com/mrishab/google-photos-delete-tool/issues/32), [#56](https://github.com/mrishab/google-photos-delete-tool/issues/56), [#20](https://github.com/mrishab/google-photos-delete-tool/issues/20)) are already addressed in v2.
- New users who find this repo deserve a working path forward; maintainers of the original can keep the old script for history.

## Scope

README-only change. No script behavior changes. Happy to adjust wording or drop the PR entirely if not wanted.