### PR TITLE
docs: point readers to the actively maintained v2 continuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,17 @@
 # Google Photos Delete All Tool
 If you have ever wanted to delete your thousands of photos from the [Google Photos](https://photos.google.com/) but failed to find an easy way to do so, then this is the tool for you. This script goes through all your photos in Google Photos app on the desktop and deletes them. You can visually see the process while it happens!
 
+> **⚠️ Note (August 2026):** this original console-script repository has not been
+> updated since January 2025. Google Photos keeps changing its UI, so several bugs
+> reported in the issue tracker here (confirmation-button changes, first-run dialog,
+> deletion races) are not addressed in this code. An actively maintained continuation
+> exists:
+>
+> **[Google Photos Delete Tool v2](https://github.com/shtse8/Google-Photos-Delete-Tool)** —
+> Chrome extension, userscript, bookmarklet, or console paste, with resilient selectors,
+> localized UI, pause/resume, dry-run, and an empty-trash flow. Please report new issues
+> there. The original script below remains available for reference.
+
 # Getting Started
 Follow the step-by-step instructions below to run the tool.
 


### PR DESCRIPTION
## What

Adds a short maintenance notice at the top of the README directing visitors to the actively maintained continuation of this tool:

**[Google Photos Delete Tool v2](https://github.com/shtse8/Google-Photos-Delete-Tool)** — Chrome extension, userscript, bookmarklet, or console paste (latest v2.0.5), with resilient selectors, localized UI, pause/resume, dry-run, and an empty-trash flow.

## Why

- This repo's `delete_photos.js` has not been updated since January 2025.
- Google Photos keeps changing its DOM; the confirmation-button selector in this script is brittle and several open issues are already addressed in v2, including #40, #62, #74, #48, #32, #56, #20, #50, #24.
- New users who land here deserve a working path forward. The original script stays in place for history.

## Scope

README-only. No script behavior changes. Happy to adjust wording or drop the PR if not wanted.